### PR TITLE
Updates limit setting code

### DIFF
--- a/docs/echidna.output.rst
+++ b/docs/echidna.output.rst
@@ -12,6 +12,14 @@ echidna.output.plot module
     :undoc-members:
     :show-inheritance:
 
+echidna.output.plot_chi_squared module
+--------------------------------------
+
+.. automodule:: echidna.output.plot_chi_squared
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 echidna.output.plot_root module
 -------------------------------
 

--- a/docs/echidna.rst
+++ b/docs/echidna.rst
@@ -13,6 +13,18 @@ Subpackages
     echidna.scripts
     echidna.test
 
+Submodules
+----------
+
+echidna.utilities module
+------------------------
+
+.. automodule:: echidna.utilities
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
 Module contents
 ---------------
 

--- a/docs/echidna.scripts.rst
+++ b/docs/echidna.scripts.rst
@@ -36,6 +36,14 @@ echidna.scripts.dump_spectra_root module
     :undoc-members:
     :show-inheritance:
 
+echidna.scripts.klz_limits module
+---------------------------------
+
+.. automodule:: echidna.scripts.klz_limits
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 echidna.scripts.multi_ntuple_spectrum module
 --------------------------------------------
 

--- a/echidna/limit/limit_config.py
+++ b/echidna/limit/limit_config.py
@@ -13,8 +13,9 @@ class LimitConfig(object):
       _prior_counts (float): prior/expected counts
       _counts (list): list of count rates (*float*) to use for scaling
       _sigma (float): prior constraint on counts
-      _chi_squareds (:class:`numpy.array`): array filled with chi
-        squared corresponding to each count value
+      _chi_squareds (:class:`numpy.array`): Array col-0:
+        :obj:`chi_squared`, col-1: :obj:`get_counts`, col-2:
+        :meth:`spectra.sum()`.
 
     Args:
       prior_counts (float): prior/expected counts
@@ -25,7 +26,6 @@ class LimitConfig(object):
         self._prior_count = prior_count
         self._counts = counts
         self._sigma = sigma
-        # Chi squared array col-0: chi squared, col-1: get_counts, col-2: spectra.sum()
         self._chi_squareds = numpy.zeros(shape=(3, 0), dtype=float)
 
     def get_count(self):
@@ -56,7 +56,7 @@ class LimitConfig(object):
         Args:
           chi_squared (float): chi squared value to add
         """
-        entry_to_append = numpy.zeros((3,1))
+        entry_to_append = numpy.zeros((3, 1))
         entry_to_append[0][0] = chi_squared
         entry_to_append[1][0] = scaling
         entry_to_append[2][0] = events

--- a/echidna/output/plot_chi_squared.py
+++ b/echidna/output/plot_chi_squared.py
@@ -1,0 +1,21 @@
+from mpl_toolkits.mplot3d import Axes3D
+import pylab
+import numpy
+
+from matplotlib import rc
+
+def chi_squared_vs_signal(signal_config, **kwargs):
+    figure = pylab.figure()
+    axis = figure.add_subplot(1, 1, 1)
+    x = signal_config._chi_squareds[2]
+    pylab.xlabel("Signal counts")
+    pylab.ylabel(r"$\chi^{2}$")
+    if kwargs.get("penalty") is not None:
+        y_1 = signal_config._chi_squareds[0]
+        y_2 = kwargs.get("penalty")._chi_squareds[0]
+        axis.plot(x, y_1, "bo-", label="no penalty term")
+        axis.plot(x, y_2, "ro-", label="penalty term")  # lines and dots
+        axis.legend(loc="upper left")
+    else:
+        axis.plot(x, y, "o-")  # lines and dots
+    pylab.show()

--- a/echidna/output/plot_chi_squared.py
+++ b/echidna/output/plot_chi_squared.py
@@ -2,9 +2,21 @@ from mpl_toolkits.mplot3d import Axes3D
 import pylab
 import numpy
 
-from matplotlib import rc
 
 def chi_squared_vs_signal(signal_config, **kwargs):
+    """ Plot the chi squared as a function of signal counts
+
+    Args:
+      signal_config (:class:`echidna.limit.limit_config.LimitConfig`): signal
+        config class, where chi squareds have been stored.
+
+    .. note::
+
+      Keyword arguments include:
+
+        * penalty (:class:`echidna.limit.limit_config.LimitConfig`): config
+          for signal with penalty term.
+    """
     figure = pylab.figure()
     axis = figure.add_subplot(1, 1, 1)
     x = signal_config._chi_squareds[2]

--- a/echidna/output/store.py
+++ b/echidna/output/store.py
@@ -33,6 +33,7 @@ def dump(file_path, spectra):
 
         file_.create_dataset("data", data=spectra._data, compression="gzip")
 
+
 def dump_ndarray(file_path, ndarray_object):
     """ Dump any other class, mostly containing numpy arrays.
 
@@ -68,7 +69,8 @@ def load(file_path):
       Loaded spectra (:class:`echidna.core.spectra.Spectra`).
     """
     with h5py.File(file_path, "r") as file_:
-        spectra = echidna.core.spectra.Spectra(file_.attrs["name"], file_.attrs["num_decays"])
+        spectra = echidna.core.spectra.Spectra(file_.attrs["name"],
+                                               file_.attrs["num_decays"])
         spectra._energy_low = file_.attrs["energy_low"]
         spectra._energy_high = file_.attrs["energy_high"]
         spectra._energy_bins = file_.attrs["energy_bins"]
@@ -101,4 +103,3 @@ def load_ndarray(file_path, ndarray_object):
             else:
                 setattr(ndarray_object, attr_name, file_.attrs[attr_name])
     return ndarray_object
-

--- a/echidna/output/store.py
+++ b/echidna/output/store.py
@@ -1,5 +1,10 @@
-import h5py
+import numpy
+
 import echidna.core.spectra
+import echidna.limit.limit_setting as limit_setting
+
+import h5py
+import sys
 
 
 def dump(file_path, spectra):
@@ -28,6 +33,30 @@ def dump(file_path, spectra):
 
         file_.create_dataset("data", data=spectra._data, compression="gzip")
 
+def dump_ndarray(file_path, ndarray_object):
+    """ Dump any other class, mostly containing numpy arrays.
+
+    Args:
+      file_path (string): Location to save to.
+      ndarray_object (object): Any class instance mainly consisting of
+        numpy array(s).
+
+    Raises:
+      AttributeError: If attribute in not an ndarray and is larger than
+        64k - h5py limit for attribute sizes.
+    """
+    with h5py.File(file_path, "w") as file_:
+        for attr_name, attribute in ndarray_object.__dict__.iteritems():
+            if type(attribute).__name__ == "ndarray":
+                file_.create_dataset(attr_name, data=attribute,
+                                     compression="gzip")
+            elif sys.getsizeof(attribute) < 65536:  # 64k
+                file_.attrs[attr_name] = attribute
+            else:
+                raise AttributeError("attribute " + str(attr_name) + " is not "
+                                     "an 'ndarray' and is too large to be "
+                                     "saved as an h5py attribute.")
+
 
 def load(file_path):
     """ Load a spectra from file_path.
@@ -55,3 +84,21 @@ def load(file_path):
 
         spectra._data = file_["data"].value
     return spectra
+
+
+def load_ndarray(file_path, ndarray_object):
+    """ Dump any other class, mostly containing numpy arrays.
+
+    Args:
+      file_path (string): Location to load class attributes from.
+      array_object (object): Any class instance mainly consisting of
+        numpy array(s).
+    """
+    with h5py.File(file_path, "r") as file_:
+        for attr_name, attribute in ndarray_object.__dict__.iteritems():
+            if type(attribute).__name__ == "ndarray":
+                setattr(ndarray_object, attr_name, file_[attr_name].value)
+            else:
+                setattr(ndarray_object, attr_name, file_.attrs[attr_name])
+    return ndarray_object
+

--- a/echidna/scripts/zero_nu_limit.py
+++ b/echidna/scripts/zero_nu_limit.py
@@ -23,56 +23,80 @@ import echidna.output.store as store
 import echidna.limit.limit_config as limit_config
 import echidna.limit.limit_setting as limit_setting
 import echidna.limit.chi_squared as chi_squared
+import echidna.output.plot_chi_squared as plot_chi_squared
 
 
 if __name__ == "__main__":
+    import argparse
+    
+
+    parser = argparse.ArgumentParser(description="Example limit setting script")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print progress and timing information")
+    args = parser.parse_args()
+
     # Create signal spectrum
     Te130_0n2b = store.load(echidna.__echidna_home__ +
-                            "data/TeLoadedTe130_0n2b.ntuple_reco.hdf5")
+                            "/data/Te130_0n2b_mc_smeared.hdf5")
+    print Te130_0n2b._name
 
     # Create background spectra
     Te130_2n2b = store.load(echidna.__echidna_home__ +
-                            "data/TeLoadedTe130_2n2b.ntuple_reco.hdf5")
-    B8 = store.load(echidna.__echidna_home__ +
-                    "data/TeLoadedB8.ntuple_reco.hdf5")
+                            "/data/Te130_2n2b_mc_smeared.hdf5")
+    print Te130_2n2b._name
+    B8_Solar = store.load(echidna.__echidna_home__ +
+                          "/data/B8_Solar_mc_smeared.hdf5")
+    print B8_Solar._name
 
     # Shrink spectra to 5 years - livetime used by Andy
     # And make 3.5m fiducial volume cut
+    # Temporary fix to _num_decays and _raw_events
+    Te130_0n2b._num_decays = Te130_0n2b.sum()
+    Te130_0n2b._raw_events = 200034
     Te130_0n2b.shrink(0.0, 10.0, 0.0, 3500.0, 0.0, 5.0)
+    Te130_2n2b._num_decays = Te130_2n2b.sum()
+    Te130_2n2b._raw_events = 75073953
     Te130_2n2b.shrink(0.0, 10.0, 0.0, 3500.0, 0.0, 5.0)
-    B8.shrink(0.0, 10.0, 0.0, 3500.0, 0.0, 5.0)
+    B8_Solar._num_decays = B8_Solar.sum()
+    B8_Solar._raw_events = 106228
+    B8_Solar.shrink(0.0, 10.0, 0.0, 3500.0, 0.0, 5.0)
 
     # Create list of backgrounds
     backgrounds = []
     backgrounds.append(Te130_2n2b)
-    backgrounds.append(B8)
+    backgrounds.append(B8_Solar)
 
     # Initialise limit setting class
     roi = (2.46, 2.68)  # Define ROI - as used by Andy
-    set_limit = limit_setting.LimitSetting(Te130_0n2b, backgrounds, roi=roi)
+    set_limit = limit_setting.LimitSetting(Te130_0n2b, backgrounds, roi=roi,
+                                           pre_shrink=True,
+                                           verbose=args.verbose)
 
     # Configure Te130_0n2b
-    Te130_0n2b_counts = numpy.arange(10.0, 6.0e3, 10.0, dtype=float)
-    Te130_0n2b_prior = 4.2077507e3  # Based on T_1/2 = 6.2e24 y for 10 years
+    Te130_0n2b_counts = numpy.arange(5.0, 500.0, 5.0, dtype=float)
+    Te130_0n2b_prior = 262.0143  # Based on T_1/2 = 9.94e25 y @ 90% CL
+                                 # (SNO+-doc-2593-v8) for 5 year livetime
+                                 # Note extrapolating here to 10 years
     Te130_0n2b_config = limit_config.LimitConfig(Te130_0n2b_prior,
                                                  Te130_0n2b_counts)
     set_limit.configure_signal(Te130_0n2b_config)
 
     # Configure Te130_2n2b
-    Te130_2n2b_counts = numpy.arange(11.342632e6, 11.342633e6,
+    Te130_2n2b_counts = numpy.arange(11.323579e6, 11.323580e6,
                                      1.0, dtype=float)
     # no penalty term to start with so just an array containing one value
-    Te130_2n2b_prior = 11.342632e6  # Based on T_1/2 = 2.3e21 y for 10 years
+    Te130_2n2b_prior = 11.323579e6  # Based on T_1/2 = 2.3e21 y for 10 years
     Te130_2n2b_config = limit_config.LimitConfig(Te130_2n2b_prior,
                                                  Te130_2n2b_counts)
-    set_limit.configure_background(Te130_2n2b._name, background_config)
+    set_limit.configure_background(Te130_2n2b._name, Te130_2n2b_config)
     # configs should have same name as background
 
-    # Configure B8
-    B8_counts = numpy.arange(12529.9691, 12530.9691, 1.0, dtype=float)
+    # Configure B8_Solar
+    B8_Solar_counts = numpy.arange(12529.9691, 12530.9691, 1.0, dtype=float)
     # again, no penalty term for now
-    B8_prior = 12529.9691  # from integrating whole spectrum scaled to Valentina's number
-    B8_config = limit_config.LimitConfig(B8_prior, B8_counts)
+    B8_Solar_prior = 12529.9691  # from integrating whole spectrum scaled to Valentina's number
+    B8_Solar_config = limit_config.LimitConfig(B8_Solar_prior, B8_Solar_counts)
+    set_limit.configure_background(B8_Solar._name, B8_Solar_config)
 
     # Set chi squared calculator
     calculator = chi_squared.ChiSquared()
@@ -82,17 +106,35 @@ if __name__ == "__main__":
     print "90% CL at: " + str(set_limit.get_limit()) + " counts"
 
     # Now try with a penalty term
-    # Set new configs this time with more counts
-    Te130_2n2b_counts = numpy.arange(5.5e6, 16.5e6, 0.01e6, dtype=float)
-    sigma = 50.0  # To use in penalty term
-    Te130_2n2b_config = limit_config.LimitConfig(Te130_2n2b_prior,
-                                                 Te130_2n2b_counts, sigma)
-    set_limit.configure_background(Te130_2n2b._name, Te130_2n2b_config)
+    # Configure Te130_0n2b
+    Te130_0n2b_counts = numpy.arange(5.0, 500.0, 5.0, dtype=float)
+    Te130_0n2b_prior = 262.0143  # Based on T_1/2 = 9.94e25 y @ 90% CL
+                                 # (SNO+-doc-2593-v8) for 5 year livetime
+                                 # Note extrapolating here to 10 years
+    Te130_0n2b_penalty_config = limit_config.LimitConfig(Te130_0n2b_prior,
+                                                         Te130_0n2b_counts)
+    set_limit.configure_signal(Te130_0n2b_penalty_config)
 
-    B8_counts = numpy.arange(6.0e3, 18.0e3, 0.01e3, dtype=float)
-    sigma = 50.0  # To use in penalty term
-    B8_config = limit_config.LimitConfig(B8_prior, B8_counts, sigma)
-    set_limit.configure_background(B8._name, B8_config)
+    # Set new configs this time with more counts
+    Te130_2n2b_counts = numpy.arange(8.7e6, 13.3e6, 0.1e6, dtype=float)
+    sigma = 2.2647e6  # To use in penalty term (20%, Andy's document on systematics)
+    Te130_2n2b_penalty_config = limit_config.LimitConfig(Te130_2n2b_prior,
+                                                         Te130_2n2b_counts,
+                                                         sigma)
+    set_limit.configure_background(Te130_2n2b._name, Te130_2n2b_penalty_config,
+                                   plot_systematic=True)
+
+    B8_Solar_counts = numpy.arange(12.0e3, 13.0e3, 0.1e3, dtype=float)
+    sigma = 501.1988  # To use in penalty term
+    B8_Solar_penalty_config = limit_config.LimitConfig(B8_Solar_prior,
+                                                       B8_Solar_counts, sigma)
+    set_limit.configure_background(B8_Solar._name, B8_Solar_penalty_config,
+                                   plot_systematic=True)
 
     # Calculate confidence limit
     print "90% CL at: " + str(set_limit.get_limit()) + " counts"
+    plot_chi_squared.chi_squared_vs_signal(Te130_0n2b_config,
+                                           penalty=Te130_0n2b_penalty_config)
+
+    for syst_analyser in set_limit._syst_analysers.values():
+        store.dump_ndarray(syst_analyser._name+".hdf5", syst_analyser)

--- a/echidna/test/test_limit_setting.py
+++ b/echidna/test/test_limit_setting.py
@@ -136,4 +136,5 @@ class TestLimitSetting(unittest.TestCase):
 
         # Check chi squareds have been recorded for each background
         for config in limit_setter_3._background_configs.values():
-            self.assertTrue(config._chi_squareds)
+            chi_squareds = config._chi_squareds
+            self.assertTrue(chi_squareds.shape[1] > 0)

--- a/echidna/utilities.py
+++ b/echidna/utilities.py
@@ -1,0 +1,33 @@
+""" Utilities module to include functions that may be useful throughout
+echidna.
+"""
+import time
+
+
+class Timer:
+    """ Useful timer class to show time elapsed performing a code block.
+
+    Examples:
+      >>> With Timer() as t:
+      ...     # block of code to time
+      >>> print ('Code executed in %.03f sec.' % t._interval)
+    """
+    def __enter__(self):
+        """
+        Attributes:
+          _start (float): start time of code block
+
+        Returns:
+          :class:`Timer`: class instance
+        """
+        self._start = time.clock()
+        return self
+
+    def __exit__(self, *args):
+        """
+        Attributes:
+          _end (float): end time of code block
+          _interval (float): time elapsed during code block
+        """
+        self._end = time.clock()
+        self._interval = self._end - self._start


### PR DESCRIPTION
Includes:

Bug fixes/updates:

  * Updates to `limit_config` class. Limit setting code was returning scaled
    counts at limit rather than `spectra.sum()` counts. Changes `_chi_squareds`
    to have 3 columns: chi squared, current count and sum. Changed other
    class methods accordingly.
  * Updates `zero_nu_limit` script:
    * Now uses smeared hdf5s
    * Decreases granularity in loops --> was too slow
    * Updated count values, priors
    * Saves systematic analysers (see below)
    * Plots signal vs chi squared
    * Adds verbosity option

New:

  * Adds `SystAnalyser` class to `limit_setting`. A class for analysing the
    effect of systematics. Creates instances via
    `LimitSetting.configure_background`.
  * Adds `utilities` module and timing utility
  * Adds `plot_chi_squared` module with `chi_squared_vs_signal` method. More to
    follow.
  * Adds `dump_ndarray` and `load_ndarray` functions to `store` module. These
    allow you to dump/load any class instance that is mainly numpy arrays, e.g.
    `SystAnalyser` class.