### PR TITLE
Zero bin approximation

### DIFF
--- a/echidna/limit/chi_squared.py
+++ b/echidna/limit/chi_squared.py
@@ -131,7 +131,8 @@ def pearson_chi_squared(observed, expected):
     """
     if len(observed) != len(expected):
         raise ValueError("Arrays are different lengths")
-    epsilon = 1e-34  # In the limit of zero
+    # Chosen due to backgrounds with low rates in ROI
+    epsilon = 1e-34 # Limit of zero
     total = 0
     for i in range(len(observed)):
         if expected[i] < epsilon:
@@ -165,6 +166,7 @@ def neyman_chi_squared(observed, expected):
     """
     if len(observed) != len(expected):
         raise ValueError("Arrays are different lengths")
+    # Chosen due to backgrounds with low rates in ROI
     epsilon = 1e-34  # In the limit of zero
     total = 0
     for i in range(len(observed)):
@@ -203,6 +205,7 @@ def log_likelihood(observed, expected):
     """
     if len(observed) != len(expected):
         raise ValueError("Arrays are different lengths")
+    # Chosen due to backgrounds with low rates in ROI
     epsilon = 1e-34  # In the limit of zero
     total = 0
     for i in range(len(observed)):

--- a/echidna/limit/chi_squared.py
+++ b/echidna/limit/chi_squared.py
@@ -108,6 +108,7 @@ class ChiSquared(object):
                                            penalty_term.get("sigma"), 2.0)
         return chi_squared
 
+
 def pearson_chi_squared(observed, expected):
     """ Calculates Pearson's chi squared.
 
@@ -161,7 +162,7 @@ def neyman_chi_squared(observed, expected):
 
     Returns:
       float: Calculated Neyman's chi squared
-    """ 
+    """
     if len(observed) != len(expected):
         raise ValueError("Arrays are different lengths")
     epsilon = 1e-34  # In the limit of zero

--- a/echidna/limit/chi_squared.py
+++ b/echidna/limit/chi_squared.py
@@ -108,30 +108,6 @@ class ChiSquared(object):
                                            penalty_term.get("sigma"), 2.0)
         return chi_squared
 
-
-def check_bin_content(array):
-    """ Checks bin content of a numpy array.
-
-    Bin content must be > 0 to be used in chi squared calculations
-
-    Args:
-      array (:class:`numpy.array`, *float*): Array or value to check
-
-    Returns:
-      tuple: (result of check (*bool*), error message (*str*))
-    """
-    if (numpy.sum(array <= 0.0) != 0):
-        result = False
-        zero_bins, = numpy.where(array <= 0.0)
-        message = "array contains " + str(len(zero_bins)) + \
-            " bins with content <= 0.0. First instance at bin " + \
-            str(zero_bins[0]) + "."
-    else:
-        result = True
-        message = "array - all bins > 0.0"
-    return result, message
-
-
 def pearson_chi_squared(observed, expected):
     """ Calculates Pearson's chi squared.
 
@@ -147,20 +123,23 @@ def pearson_chi_squared(observed, expected):
         events
 
     Raises:
-      ValueError: If either array contains a bin with content <= 0.0
+      ValueError: If arrays are different lengths.
 
     Returns:
       float: Calculated Pearson's chi squared
     """
-    correct_bin_content, message = check_bin_content(observed)
-    if not correct_bin_content:
-        raise ValueError("chi_squared.pearson_chi_squared: observed " +
-                         message)
-    correct_bin_content, message = check_bin_content(expected)
-    if not correct_bin_content:
-        raise ValueError("chi_squared.pearson_chi_squared: expected " +
-                         message)
-    return numpy.sum((observed-expected)**2 / expected)
+    if len(observed) != len(expected):
+        raise ValueError("Arrays are different lengths")
+    epsilon = 1e-34  # In the limit of zero
+    total = 0
+    for i in range(len(observed)):
+        if expected[i] < epsilon:
+            expected[i] = epsilon
+        if observed[i] < epsilon:
+            total += expected[i]
+        else:
+            total += (observed[i]-expected[i])**2/expected[i]
+    return total
 
 
 def neyman_chi_squared(observed, expected):
@@ -178,20 +157,23 @@ def neyman_chi_squared(observed, expected):
         events
 
     Raises:
-      ValueError: If either array contains a bin with content <= 0.0
+      ValueError: If arrays are different lengths
 
     Returns:
       float: Calculated Neyman's chi squared
-    """
-    correct_bin_content, message = check_bin_content(observed)
-    if not correct_bin_content:
-        raise ValueError("chi_squared.pearson_chi_squared: observed " +
-                         message)
-    correct_bin_content, message = check_bin_content(expected)
-    if not correct_bin_content:
-        raise ValueError("chi_squared.pearson_chi_squared: expected " +
-                         message)
-    return numpy.sum((observed-expected)**2 / observed)
+    """ 
+    if len(observed) != len(expected):
+        raise ValueError("Arrays are different lengths")
+    epsilon = 1e-34  # In the limit of zero
+    total = 0
+    for i in range(len(observed)):
+        if observed[i] < epsilon:
+            expected[i] = epsilon
+        if expected[i] < epsilon:
+            total += observed[i]
+        else:
+            total += (expected[i]-observed[i])**2/observed[i]
+    return total
 
 
 def log_likelihood(observed, expected):
@@ -213,18 +195,20 @@ def log_likelihood(observed, expected):
         events
 
     Raises:
-      ValueError: If either array contains a bin with content <= 0.0
+      ValueError: If arrays are different lengths.
 
     Returns:
       float: Calculated Neyman's chi squared
     """
-    correct_bin_content, message = check_bin_content(observed)
-    if not correct_bin_content:
-        raise ValueError("chi_squared.pearson_chi_squared: observed " +
-                         message)
-    correct_bin_content, message = check_bin_content(expected)
-    if not correct_bin_content:
-        raise ValueError("chi_squared.pearson_chi_squared: expected " +
-                         message)
-    return numpy.sum(expected - observed +
-                     observed*numpy.log(observed/expected))
+    if len(observed) != len(expected):
+        raise ValueError("Arrays are different lengths")
+    epsilon = 1e-34  # In the limit of zero
+    total = 0
+    for i in range(len(observed)):
+        if expected[i] < epsilon:
+            expected[i] = epsilon
+        if observed[i] < epsilon:
+            total += expected[i]
+        else:
+            total += expected[i]-observed[i]+observed[i]*numpy.log(observed[i]/expected[i])
+    return total

--- a/echidna/test/test_chi_squared.py
+++ b/echidna/test/test_chi_squared.py
@@ -12,43 +12,61 @@ class TestChiSquared(unittest.TestCase):
 
         Tests that the function calculates accurate values
         """
-        self.assertEqual(chi_squared.pearson_chi_squared(100.0, 110.0),
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([110.0])
+        self.assertEqual(chi_squared.pearson_chi_squared(array1, array2),
                          (10.0 / 11.0))
-        self.assertEqual(chi_squared.pearson_chi_squared(100.0, 90.0),
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([90.0])
+        self.assertEqual(chi_squared.pearson_chi_squared(array1, array2),
                          (10.0 / 9.0))
-        self.assertEqual(chi_squared.pearson_chi_squared(100.0, 100.0), 0.0)
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([100.0])
+        self.assertEqual(chi_squared.pearson_chi_squared(array1, array2), 0.0)
+        array1 = numpy.array([1])
+        array2 = numpy.array([1, 2])
         self.assertRaises(ValueError, chi_squared.pearson_chi_squared,
-                          0.0, 100.0)
-        self.assertRaises(ValueError, chi_squared.pearson_chi_squared,
-                          100.0, 0.0)
+                          array1, array2)
 
     def test_neyman_chi_squared(self):
         """ Test the neyman chi squared function
 
         Tests that the function calculates accurate values
         """
-        self.assertEqual(chi_squared.neyman_chi_squared(100.0, 110.0), 1.0)
-        self.assertEqual(chi_squared.neyman_chi_squared(100.0, 90.0), 1.0)
-        self.assertEqual(chi_squared.neyman_chi_squared(100.0, 100.0), 0.0)
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([110.0])
+        self.assertEqual(chi_squared.neyman_chi_squared(array1, array2), 1.0)
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([90.0])
+        self.assertEqual(chi_squared.neyman_chi_squared(array1, array2), 1.0)
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([100.0])
+        self.assertEqual(chi_squared.neyman_chi_squared(array1, array2), 0.0)
+        array1 = numpy.array([1])
+        array2 = numpy.array([1, 2])
         self.assertRaises(ValueError, chi_squared.neyman_chi_squared,
-                          0.0, 100.0)
-        self.assertRaises(ValueError, chi_squared.neyman_chi_squared,
-                          100.0, 0.0)
+                          array1, array2)
 
     def test_log_likelihood(self):
         """ Test the log likelihood function
 
         Tests that the function calculates accurate values
         """
-        self.assertAlmostEqual(2.0 * chi_squared.log_likelihood(100.0, 110.0),
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([110.0])
+        self.assertAlmostEqual(2.0*chi_squared.log_likelihood(array1, array2),
                                0.9379640391350215)
-        self.assertAlmostEqual(2.0 * chi_squared.log_likelihood(100.0, 90.0),
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([90.0])
+        self.assertAlmostEqual(2.0*chi_squared.log_likelihood(array1, array2),
                                1.072103131565271)
-        self.assertEqual(chi_squared.log_likelihood(100.0, 100.0), 0.0)
+        array1 = numpy.array([100.0])
+        array2 = numpy.array([100.0])
+        self.assertEqual(chi_squared.log_likelihood(array1, array2), 0.0)
+        array1 = numpy.array([1])
+        array2 = numpy.array([1, 2])
         self.assertRaises(ValueError, chi_squared.log_likelihood,
-                          0.0, 100.0)
-        self.assertRaises(ValueError, chi_squared.log_likelihood,
-                          100.0, 0.0)
+                          array1, array2)
 
     def test_get_chi_squared(self):
         """ Tests get chi squared method

--- a/echidna/test/test_limit_setting.py
+++ b/echidna/test/test_limit_setting.py
@@ -91,7 +91,6 @@ class TestLimitSetting(unittest.TestCase):
         limit_setter_1.configure_background("bkg_1", bkg_1_config)
         self.assertRaises(TypeError, limit_setter_1.get_limit)
         limit_setter_1.set_calculator(calculator)
-        self.assertRaises(ValueError, limit_setter_1.get_limit)
 
         # Test 2: different limits with and without penalty term
         # Define ROI


### PR DESCRIPTION
Adjusted chi-sq code to handle the limit of 0 entry bins

Based on this coding snippet from MINOS,  courtesy of J. Hartnell.

```C++
Double_t LogLikelihood(Double_t dnu, Double_t mnu)
{
  if (dnu) {
    // Protection against cases where there is data but no MC?
    // This should not normally be possible, other than highly contrived
    // unphysical oscillation values.
    // Set the value to something lower than POT_Data / POT_MC, which at the
    // moment is usually 1e-3. We can justify this as an error on the MC
    const Double_t MCError = 1e-7;
    //if (mnu < MCError || isnan(mnu)) mnu = MCError;
    if (mnu < MCError) mnu = MCError;

    // We have both values. Do the proper lnL!
    return 2*(mnu - dnu + dnu*log(dnu/mnu));
  } else {
    // dnu is zero, mnu may or may not be zero
    return 2*mnu;
  }
} 
```