### PR TITLE
Adds online docs and updated README.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+docs/html  # separated out html docs for GitHub Pages 
 
 # PyBuilder
 target/

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ from the echidna base directory. Details on how to run individual scripts can be
 Documentation
 -------------
 
-A copy of the latest version of the HTML documentation is available [here](echidna/blob/gh-pages/docs/html/docs/index.html)
+A copy of the latest version of the HTML documentation is available [here](https://snoplusuk.github.io/echidna/docs/index.html)
 
 But if you prefer you can build a copy of the Sphinx-based documentation locally. To build HTML documentation:
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,69 @@
 echidna
 =======
-A limit setting and spectrum fitting tool.
 
-Documentation
--------------
-Sphinx based documentation is available in the `docs` directory. To build HTML documentation,
+echidna is a limit setting and spectrum fitting tool. It aims to create a fast flexible platform providing the tools for a variety of limit-setting and fitting based analyses.
 
-    cd docs
-    make html
+Getting started with echidna
+----------------------------
 
-Output is placed in `doc/_build/html`.
-This documentation is built using the napoleon extension to sphinx, which allows the google style comments.
+Whether you want to contribute to development or just use the latest release, this is the place to start.
 
-Note: After updating code be sure to run in the base directory
-    
-    sphinx-apidoc -f -H echidna -o docs echidna/
-    cd docs
-    make html
+Downloading echidna
+-------------------
+
+If you just want the latest release, there are two main options:
+
+* [download](https://github.com/snoplusuk/echidna/releases/latest) the latest release from GitHub
+* Clone the repository from the command line
+
+
+        $ git clone -b "v0.1-alpha" git@github.com:snoplusuk/echidna.git
+
+However if you plan on developing echidna, the best option is to fork the main
+echidna repository and then clone your fork
+
+    $ git clone git@github.com:yourusername/echidna.git
 
 Software Requirements
 ---------------------
 
-The software and corresponding version numbers required to run echidna are listed in requirements.txt. To install all packages using pip run
+In order run echidna some extra python modules are required. The software and corresponding version numbers required listed in requirements.txt. To install all packages using pip run
 
-    sudo pip install -r requirements.txt
+    $ pip install -r requirements.txt
+
+Note: you may need root access to install some modules.
 
 Running echidna
 ---------------
 
-Example scripts are located in the echidna/scripts/ folder. To run example scripts you must set your python path to
+You should now have a working copy of echidna. You can get started straight away by using some of the example scripts. Example scripts are located in `echidna/scripts/`. To run example scripts you must set your python path to
 
-    export PYTHONPATH=$PYTHONPATH:$(pwd)
+    $ export PYTHONPATH=$PYTHONPATH:$(pwd)
 
 from the echidna base directory. Details on how to run individual scripts can be found in their respective documentation.
+
+Documentation
+-------------
+
+A copy of the latest version of the HTML documentation is available [here](echidna/blob/gh-pages/docs/html/docs/index.html)
+
+But if you prefer you can build a copy of the Sphinx-based documentation locally. To build HTML documentation:
+
+    $ cd docs
+    $ make html
+
+Output is placed in `docs/html/docs`. This documentation is built using the napoleon extension to sphinx, which allows the google style comments.
+
+Note: After updating code be sure to run in the base directory
+    
+    $ sphinx-apidoc -f -H echidna -o docs echidna/
+    $ cd docs
+    $ make html
 
 Testing
 -------
 To test the code is working as expected run
 
-    python -m unittest discover echidna/test/
+    $ python -m unittest discover echidna/test/
+
+from the base directory.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+HTMLBUILDDIR  = html
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -50,9 +51,9 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(HTMLBUILDDIR)/docs
 	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+	@echo "Build finished. The HTML pages are in $(HTMLBUILDDIR)/docs."
 
 dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml

--- a/docs/echidna.calc.rst
+++ b/docs/echidna.calc.rst
@@ -1,0 +1,30 @@
+echidna.calc package
+====================
+
+Submodules
+----------
+
+echidna.calc.constants module
+-----------------------------
+
+.. automodule:: echidna.calc.constants
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+echidna.calc.decay module
+-------------------------
+
+.. automodule:: echidna.calc.decay
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: echidna.calc
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Modifies output for sphinx `make html` build, so that html documentation can be
included on gh-pages.

Adds `gh-pages` sub-directory to `.gitignore`.

Modifies `README.md` in light of some comments at echidna meeting and also so
that its content can be used as `index` in `gh-pages`.

Finally adds `echidna.calc.rst`, an untracked file that should already be
tracked.