### PR TITLE
Majoron script update

### DIFF
--- a/echidna/scripts/Xe136_majoron_limit.py
+++ b/echidna/scripts/Xe136_majoron_limit.py
@@ -172,8 +172,8 @@ def main(args):
                                                  Xe136_2n2b_counts, sigma)
 
     # B8_Solar
-    # Assume same rate as SNO+ for now
-    B8_Solar_prior = 1252.99691
+    # Assume same rate as SNO+ for now (fom SNO+-doc-507)
+    B8_Solar_prior = 1270. * livetime  # 1270 events/year over livetime
     # No penalty term
     B8_Solar_counts_np = numpy.array([B8_Solar_prior])
     B8_Solar_config_np = limit_config.LimitConfig(B8_Solar_prior,

--- a/echidna/scripts/Xe136_majoron_limit.py
+++ b/echidna/scripts/Xe136_majoron_limit.py
@@ -172,8 +172,8 @@ def main(args):
                                                  Xe136_2n2b_counts, sigma)
 
     # B8_Solar
-    # Assume same rate as SNO+ for now (fom SNO+-doc-507)
-    B8_Solar_prior = 1270. * livetime  # 1270 events/year over livetime
+    # Assume same rate as SNO+ for now (fom SNO+-doc-507v27)
+    B8_Solar_prior = 1021. * livetime  # 1021 events/year over livetime
     # No penalty term
     B8_Solar_counts_np = numpy.array([B8_Solar_prior])
     B8_Solar_config_np = limit_config.LimitConfig(B8_Solar_prior,


### PR DESCRIPTION
Modifies the `Xe136_majoron_limit` script in light of some changes introduced
in PR #76.

Continuing, for now, with the assumption that KamLAND-Zen has the same expected
solar rate as SNO+, updates the `B8_Solar` prior to be the expected rate for the
full 0-15 MeV range from SNO+-doc-507. Note this number has been updated in
SNO+-doc-507v27 for the whitepaper.