### PR TITLE
Closes #92.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-Sphinx==1.3b2
+scipy==0.16.0
 h5py==2.4.0
-numpy==1.9.1
-scipy==0.9.0
 pyyaml==3.11
 matplotlib==1.4.3
+Sphinx==1.3b2


### PR DESCRIPTION
I think the problem with the requirements file, was coming from an
old version of SciPy. I've upgraded to the latest version of SciPy.
Also installing both SciPy and numpy was causing problems. Since
numpy is installed as part of the SciPy package, I've removed the
separate install of numpy and we should just use the version that
is installed with the current SciPy version.