### PR TITLE
Fixes #80.

### DIFF
--- a/echidna/core/spectra.py
+++ b/echidna/core/spectra.py
@@ -324,7 +324,7 @@ class Spectra(object):
         self._style = {"color": "blue"}  # default style for plotting
         self._rois = {}
         self._name = name
-        self._num_decays = num_decays
+        self._num_decays = float(num_decays)
 
     def get_config(self):
         """ Get the config of the spectra.
@@ -491,22 +491,10 @@ class Spectra(object):
 
         Args:
           num_decays (float): Number of decays this spectra should represent.
-
-        .. warning:: Since :attr:`_num_decays` is set to equal the
-          :obj:`num_decays` supplied here, after calling :meth:`scale`,
-          the type of :attr:`_num_decays` will match the type of
-          :obj:`num_decays` supplied. E.g.::
-
-            >>> spectrum.scale(100)
-            >>> isinstance(spectrum._num_decays, int)  # True
-            >>> spectrum.scale(100.)
-            >>> isinstance(spectrum._num_decays, float)  # True
-
         """
-        # Cast self._num_decays as float
-        self._data = numpy.multiply(self._data,
-                                    num_decays / float(self._num_decays))
-        self._num_decays = num_decays
+        self._data = numpy.multiply(self._data, num_decays / self._num_decays)
+        # Make sure self._num_decays stays as a float
+        self._num_decays = float(num_decays)
 
     def shrink(self, **kwargs):
         """ Shrink the data such that it only contains values between low and

--- a/echidna/core/spectra.py
+++ b/echidna/core/spectra.py
@@ -492,12 +492,17 @@ class Spectra(object):
         Args:
           num_decays (float): Number of decays this spectra should represent.
 
-        .. warning:: Regardless of initial type (often initially of type
-          :class:`int`), :attr:`self._num_decays` will always become
-          type :class:`float` after calling :meth:`scale`.
+        .. warning:: Since :attr:`_num_decays` is set to equal the
+          :obj:`num_decays` supplied here, after calling :meth:`scale`,
+          the type of :attr:`_num_decays` will match the type of
+          :obj:`num_decays` supplied. E.g.::
+
+            >>> spectrum.scale(100)
+            >>> isinstance(spectrum._num_decays, int)  # True
+            >>> spectrum.scale(100.)
+            >>> isinstance(spectrum._num_decays, float)  # True
+
         """
-        if isinstance(num_decays, int):  # convert to float
-            num_decays = float(num_decays)
         # Cast self._num_decays as float
         self._data = numpy.multiply(self._data,
                                     num_decays / float(self._num_decays))

--- a/echidna/core/spectra.py
+++ b/echidna/core/spectra.py
@@ -491,8 +491,16 @@ class Spectra(object):
 
         Args:
           num_decays (float): Number of decays this spectra should represent.
+
+        .. warning:: Regardless of initial type (often initially of type
+          :class:`int`), :attr:`self._num_decays` will always become
+          type :class:`float` after calling :meth:`scale`.
         """
-        self._data = numpy.multiply(self._data, num_decays / self._num_decays)
+        if isinstance(num_decays, int):  # convert to float
+            num_decays = float(num_decays)
+        # Cast self._num_decays as float
+        self._data = numpy.multiply(self._data,
+                                    num_decays / float(self._num_decays))
         self._num_decays = num_decays
 
     def shrink(self, **kwargs):

--- a/echidna/test/test_spectra.py
+++ b/echidna/test/test_spectra.py
@@ -97,8 +97,6 @@ class TestSpectra(unittest.TestCase):
         test_spectra.scale(count)
         # Check sum != 0.0
         self.assertNotEqual(test_spectra.sum(), 0.0)
-        # Check num_decays is converted to float
-        self.assertIsInstance(test_spectra._num_decays, float)
         self.assertTrue(test_spectra.sum() == count,
                         msg="Spectra sum: %s, scaling %s"
                         % (test_spectra.sum(), count))

--- a/echidna/test/test_spectra.py
+++ b/echidna/test/test_spectra.py
@@ -78,7 +78,7 @@ class TestSpectra(unittest.TestCase):
 
         This creates a spectra and then scales it.
         """
-        test_decays = 10
+        test_decays = 10  # should be a float
         config_path = "echidna/config/example.yml"
         config = spectra.SpectraConfig.load_from_file(config_path)
         test_spectra = spectra.Spectra("Test", test_decays, config)
@@ -91,8 +91,14 @@ class TestSpectra(unittest.TestCase):
             radius = random.uniform(radial_low, radial_high)
             test_spectra.fill(energy_mc=energy, radial_mc=radius)
         self.assertTrue(test_spectra.sum() == test_decays)
-        count = 150
+        count = 150  # int
         test_spectra.scale(count)
+        count = 110  # int --> int(110) / int(150) = 0
+        test_spectra.scale(count)
+        # Check sum != 0.0
+        self.assertNotEqual(test_spectra.sum(), 0.0)
+        # Check num_decays is converted to float
+        self.assertIsInstance(test_spectra._num_decays, float)
         self.assertTrue(test_spectra.sum() == count,
                         msg="Spectra sum: %s, scaling %s"
                         % (test_spectra.sum(), count))

--- a/echidna/test/test_spectra.py
+++ b/echidna/test/test_spectra.py
@@ -78,7 +78,7 @@ class TestSpectra(unittest.TestCase):
 
         This creates a spectra and then scales it.
         """
-        test_decays = 10  # should be a float
+        test_decays = 10
         config_path = "echidna/config/example.yml"
         config = spectra.SpectraConfig.load_from_file(config_path)
         test_spectra = spectra.Spectra("Test", test_decays, config)


### PR DESCRIPTION
Modifies `scale` method to convert supplied `num_decays` to `float`, if it is
supplied as an `int`. Also casts `self._num_decays` as float. This should
prevent integer division resulting in scaling events to zero.

Also updates `test_scale` method accordingly.