### PR TITLE
Ignores all .rst files generated by Spynx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 docs/html  # separated out html docs for GitHub Pages 
+docs/*.rst
 
 # PyBuilder
 target/


### PR DESCRIPTION
The .rst files produced by Shynx won't appear as untracked files 