### PR TITLE
Fixes stats bug in `Summary`.

### DIFF
--- a/echidna/limit/limit.py
+++ b/echidna/limit/limit.py
@@ -187,12 +187,12 @@ class Limit(object):
         # previously calculated min_stat
         if stats.min() > min_stat:
             min_stat = stats.min()
-            if self._per_bin:
-                # Now we want the corresponding per_bin values
-                min_per_bin = limit_summary.get_raw_stat(stats.argmin())
 
         # Convert stats to delta - subtracting minimum
         stats -= min_stat
+        if self._per_bin:
+            # Now we want the corresponding per_bin values
+            min_per_bin = limit_summary.get_raw_stat(stats.argmin())
         limit_summary.set_stats(limit_summary.get_raw_stats() - min_per_bin)
 
         # Also want to know index of minimum

--- a/echidna/limit/limit.py
+++ b/echidna/limit/limit.py
@@ -193,7 +193,8 @@ class Limit(object):
         if self._per_bin:
             # Now we want the corresponding per_bin values
             min_per_bin = limit_summary.get_raw_stat(stats.argmin())
-        limit_summary.set_stats(limit_summary.get_raw_stats() - min_per_bin)
+            limit_summary.set_stats(limit_summary.get_raw_stats() -
+                                    min_per_bin)
 
         # Also want to know index of minimum
         min_bin = numpy.argmin(stats)


### PR DESCRIPTION
Summary class was often not updating the values for `min_per_bin` and using a
previous definition. This often resulted in subtracting the wrong per_bin
values when calculating delta-test-statistic and eneded up with negative values
for the test statistic. This fixes the problem by *always* redefining
`min_per_bin`.